### PR TITLE
Attempt to fix the calculation of node cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Fixed
+
+- Heap now prioritizes nodes based on fCost (gCost + hCost) instead of just gCost
+- Better cost comparison with hCost tiebreaker when fCosts are equal
+
+### Changed
+
+- Simplified bubbleUp/bubbleDown heap operations
+
+## [0.1.0] - 2025-05-01
+
+### Added
+
+- `AStarPathFinding` class with continuous and step-by-step search modes
+- Full path and waypoint-only result types
+- Configurable distance heuristics via `DistanceStrategy` interface
+- `EuclideanDistance` and `ManhattanDistance` implementations
+- `MinHeapWithNodes` optimized priority queue with O(1) existence checks
+- Support for 2D matrix and 1D array grid input
+- Unit tests (27 tests) with Istanbul coverage reporting
+- esbuild bundling configuration
+- ESLint and Prettier configuration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,54 @@
+# Pathfinding
+
+## Overview
+
+A\* pathfinding library supporting continuous or step-by-step search on 2D grids. Returns full paths or waypoint-only paths with configurable distance heuristics.
+
+## Source Structure
+
+| File                      | Description                                                       |
+| ------------------------- | ----------------------------------------------------------------- |
+| `src/AStarPathFinding.ts` | Core A\* algorithm: continuous and by-step search modes           |
+| `src/MinHeapWithNodes.ts` | Min-heap optimized for A\* with O(1) existence checks via Set     |
+| `src/DistanceStrategy.ts` | Distance strategy interface + Euclidean/Manhattan implementations |
+| `src/utils.ts`            | Utility functions (`isNumber`)                                    |
+| `src/index.ts`            | Public API re-exports                                             |
+
+## Key Exports
+
+| Export                         | Type      | Description                               |
+| ------------------------------ | --------- | ----------------------------------------- |
+| `AStarPathFinding`             | Class     | Core A\* pathfinding algorithm            |
+| `AStarPathFindingSearchType`   | Enum      | `CONTINUOUS`, `BY_STEP`                   |
+| `AStarPathFindingResultType`   | Enum      | `FULL_PATH_ARRAY`, `WAYPOINT_PATH_ARRAY`  |
+| `AStarPathFindingSearchStatus` | Enum      | `INIT`, `SEARCHING`, `FOUND`, `NOT_FOUND` |
+| `AStarPathFindingInit`         | Type      | Configuration object for initialization   |
+| `MatrixTileCoordinates`        | Type      | `{ x, y }` tile coordinates               |
+| `MinHeapNode`                  | Type      | Heap node with value, gCost, hCost, fCost |
+| `DistanceStrategy`             | Interface | `calculate(start, finish): number`        |
+| `EuclideanDistance`            | Class     | Euclidean distance heuristic              |
+| `ManhattanDistance`            | Class     | Manhattan distance heuristic              |
+
+## Dependencies
+
+None (standalone library).
+
+## Development
+
+| Command         | What it does                                |
+| --------------- | ------------------------------------------- |
+| `npm install`   | Install dependencies                        |
+| `npm run build` | Bundle with esbuild                         |
+| `npm run test`  | Run tests with coverage (vitest + istanbul) |
+| `npm run lint`  | Lint (eslint)                               |
+
+## Testing
+
+- Framework: Vitest with Istanbul coverage
+- Tests: `src/AStarPathFinding.test.ts`, `src/MinHeapWithNodes.test.ts`, `src/DistanceStrategy.test.ts`
+
+## Coding Guidelines
+
+- Consider algorithmic complexity when suggesting changes.
+- Avoid unnecessary comments in code.
+- Keep the library dependency-free.

--- a/src/AStarPathFinding.test.ts
+++ b/src/AStarPathFinding.test.ts
@@ -305,6 +305,46 @@ describe("AStarPathFinding", () => {
     });
   });
 
+  describe("init() reuse - clears stale state", () => {
+    test("calling init() twice on the same instance produces correct results", () => {
+      const matrix2D = [
+        [0, 1, 0, 0, 0],
+        [0, 1, 0, 1, 0],
+        [0, 0, 0, 1, 0],
+      ];
+
+      const aStar = new AStarPathFinding({
+        matrix2D,
+        searchType: AStarPathFindingSearchType.CONTINUOUS,
+        startCoordinates: { x: 0, y: 0 },
+        finishCoordinates: { x: 4, y: 2 },
+      });
+
+      const result1 = aStar.search();
+      expect(result1).toBe(true);
+      const path1 = [...aStar.path];
+      expect(path1.length).toBeGreaterThan(0);
+
+      // Re-init with a different search on the same instance
+      aStar.init({
+        matrix2D,
+        searchType: AStarPathFindingSearchType.CONTINUOUS,
+        startCoordinates: { x: 0, y: 2 },
+        finishCoordinates: { x: 2, y: 0 },
+      });
+
+      // State should be clean
+      expect(aStar.visitedTiles.size).toBe(0);
+      expect(aStar.cameFromTiles.size).toBe(0);
+      expect(aStar.path.length).toBe(0);
+
+      const result2 = aStar.search();
+      expect(result2).toBe(true);
+      expect(aStar.path[0]).toBe(10); // start tile (0,2)
+      expect(aStar.path[aStar.path.length - 1]).toBe(2); // end tile (2,0)
+    });
+  });
+
   describe("internal functions", () => {
     describe("20x15 matrix", () => {
       let aStar: AStarPathFinding;

--- a/src/AStarPathFinding.ts
+++ b/src/AStarPathFinding.ts
@@ -55,6 +55,8 @@ export default class AStarPathFinding {
   public visitedTiles: Set<number> = new Set();
   // Map<tile, cameFromTile>
   public cameFromTiles: Map<number, number> = new Map();
+  // Maps tileValue to best known gCost
+  private nodeCosts: Map<number, number> = new Map();
   // The path found on success.
   public path: number[] = [];
   private matrixWidth!: number;
@@ -158,7 +160,9 @@ export default class AStarPathFinding {
     this.finishTileValue = this.getTileValueFromCoordinates(config.finishCoordinates.x, config.finishCoordinates.y);
 
     // Push the first "Start" tile in order to start searching.
-    this.queue = new MinHeapWithNodes([{ value: this.startTileValue, cost: 0 }]);
+    const hCost = this.calculateDistanceBetweenTwoTiles(this.startTileValue, this.finishTileValue);
+    // console.log("hCost", hCost);
+    this.queue = new MinHeapWithNodes([{ value: this.startTileValue, hCost, gCost: 0, fCost: hCost }]);
     // Reset previously found path.
     this.path = [];
   }
@@ -318,13 +322,17 @@ export default class AStarPathFinding {
 
   private computeFutureTileValueAndCostFromDirection(node: MinHeapNode, [directionX, directionY]: [number, number]): MinHeapNode | null {
     let futureTileValue: number;
-    let futureCost: number;
+    let hCost: number;
+    let gCost: number;
+    let fCost: number;
 
     if (directionX !== 0) {
       futureTileValue = node.value + directionX;
       // Calculate this based on heuristic?
-      futureCost = this.calculateDistanceBetweenTwoTiles(futureTileValue, this.finishTileValue);
-      // console.log("futureCost", futureCost);
+      hCost = this.calculateDistanceBetweenTwoTiles(futureTileValue, this.finishTileValue);
+      gCost = node.gCost + 1;
+      fCost = hCost + gCost;
+      // console.log("fCost", fCost);
 
       // Check out of bounds.
       if ((directionX === -1 && (futureTileValue + 1) % this.matrixWidth === 0) || (directionX === 1 && futureTileValue % this.matrixWidth === 0)) {
@@ -333,14 +341,25 @@ export default class AStarPathFinding {
     } else if (directionY !== 0) {
       futureTileValue = node.value + directionY * this.matrixWidth;
       // Calculate this based on heuristic?
-      futureCost = this.calculateDistanceBetweenTwoTiles(futureTileValue, this.finishTileValue);
-      // console.log("futureCost", futureCost);
+      hCost = this.calculateDistanceBetweenTwoTiles(futureTileValue, this.finishTileValue);
+      gCost = node.gCost + 1;
+      fCost = hCost + gCost;
+      // console.log("fCost", fCost);
     } else {
       return null;
     }
 
+    // Check if we already have a better path to this node
+    const existingGCost = this.nodeCosts.get(futureTileValue) ?? Infinity;
+    if (gCost >= existingGCost) {
+      return null;
+    }
+    // Update the best known cost
+    this.nodeCosts.set(futureTileValue, gCost);
+
     // Already visited?
     if (this.visitedTiles.has(futureTileValue)) {
+      console.log("already visited", futureTileValue);
       return null;
     }
 
@@ -355,6 +374,6 @@ export default class AStarPathFinding {
     }
 
     // new MinHeapNode
-    return { value: futureTileValue, cost: futureCost };
+    return { value: futureTileValue, hCost: hCost, gCost, fCost };
   }
 }

--- a/src/AStarPathFinding.ts
+++ b/src/AStarPathFinding.ts
@@ -161,7 +161,6 @@ export default class AStarPathFinding {
 
     // Push the first "Start" tile in order to start searching.
     const hCost = this.calculateDistanceBetweenTwoTiles(this.startTileValue, this.finishTileValue);
-    // console.log("hCost", hCost);
     this.queue = new MinHeapWithNodes([{ value: this.startTileValue, hCost, gCost: 0, fCost: hCost }]);
     // Reset previously found path.
     this.path = [];
@@ -210,7 +209,7 @@ export default class AStarPathFinding {
     if (found) {
       this.status = AStarPathFindingSearchStatus.FOUND;
       this.queue.clear();
-      // console.log(this.cameFromTiles);
+
       if (this.resultType === AStarPathFindingResultType.WAYPOINT_PATH_ARRAY) {
         this.doBacktrackInflection(node);
       } else {
@@ -332,7 +331,6 @@ export default class AStarPathFinding {
       hCost = this.calculateDistanceBetweenTwoTiles(futureTileValue, this.finishTileValue);
       gCost = node.gCost + 1;
       fCost = hCost + gCost;
-      // console.log("fCost", fCost);
 
       // Check out of bounds.
       if ((directionX === -1 && (futureTileValue + 1) % this.matrixWidth === 0) || (directionX === 1 && futureTileValue % this.matrixWidth === 0)) {
@@ -344,7 +342,6 @@ export default class AStarPathFinding {
       hCost = this.calculateDistanceBetweenTwoTiles(futureTileValue, this.finishTileValue);
       gCost = node.gCost + 1;
       fCost = hCost + gCost;
-      // console.log("fCost", fCost);
     } else {
       return null;
     }
@@ -359,7 +356,6 @@ export default class AStarPathFinding {
 
     // Already visited?
     if (this.visitedTiles.has(futureTileValue)) {
-      console.log("already visited", futureTileValue);
       return null;
     }
 

--- a/src/AStarPathFinding.ts
+++ b/src/AStarPathFinding.ts
@@ -103,6 +103,9 @@ export default class AStarPathFinding {
 
   public init(config: AStarPathFindingInit): void {
     this.status = AStarPathFindingSearchStatus.INIT;
+    this.visitedTiles.clear();
+    this.cameFromTiles.clear();
+    this.nodeCosts.clear();
 
     if (config.matrix2D) {
       this.checkMatrix2D(config);
@@ -252,17 +255,44 @@ export default class AStarPathFinding {
     let lastAdded: number = node.value;
     const path: number[] = [current];
 
+    let lastDirectionX: string = "none";
+    let lastDirectionY: string = "none";
+
+    let directionX: string = "none";
+    let directionY: string = "none";
+
     while (this.cameFromTiles.has(current)) {
       const cameFrom: number = this.cameFromTiles.get(current) as number;
 
       const cameFromXY = this.getCoordinatesFromTileValue(cameFrom);
       const lastAddedXY = this.getCoordinatesFromTileValue(lastAdded);
+
+      if (lastAddedXY.x > cameFromXY.x) {
+        directionX = "right";
+      } else if (lastAddedXY.x < cameFromXY.x) {
+        directionX = "left";
+      } else {
+        directionX = "none";
+      }
+
+      if (lastAddedXY.y > cameFromXY.y) {
+        directionY = "down";
+      } else if (lastAddedXY.y < cameFromXY.y) {
+        directionY = "up";
+      } else {
+        directionY = "none";
+      }
+
+      // console.log(cameFromXY, lastAddedXY, directionX, directionY);
+
       // Check if the current tile has changed direction (row or column).
-      if (cameFromXY.x !== lastAddedXY.x && cameFromXY.y !== lastAddedXY.y) {
+      if (directionX !== lastDirectionX || directionY !== lastDirectionY) {
         lastAdded = cameFrom;
         path.unshift(current);
       }
       current = cameFrom;
+      lastDirectionX = directionX;
+      lastDirectionY = directionY;
     }
 
     // Add the starting tile.
@@ -328,8 +358,11 @@ export default class AStarPathFinding {
     if (directionX !== 0) {
       futureTileValue = node.value + directionX;
       // Calculate this based on heuristic?
+      // Heuristic cost from this node to goal.
       hCost = this.calculateDistanceBetweenTwoTiles(futureTileValue, this.finishTileValue);
+      // Actual cost from start to this node.
       gCost = node.gCost + 1;
+      // Total cost (gCost + hCost)
       fCost = hCost + gCost;
 
       // Check out of bounds.
@@ -339,8 +372,11 @@ export default class AStarPathFinding {
     } else if (directionY !== 0) {
       futureTileValue = node.value + directionY * this.matrixWidth;
       // Calculate this based on heuristic?
+      // Heuristic cost from this node to goal.
       hCost = this.calculateDistanceBetweenTwoTiles(futureTileValue, this.finishTileValue);
+      // Actual cost from start to this node.
       gCost = node.gCost + 1;
+      // Total cost (gCost + hCost)
       fCost = hCost + gCost;
     } else {
       return null;

--- a/src/MinHeapWithNodes.test.ts
+++ b/src/MinHeapWithNodes.test.ts
@@ -3,82 +3,82 @@ import MinHeapWithNodes from "./MinHeapWithNodes.ts";
 describe("MinHeapWithNodes", () => {
   it("constructor", () => {
     const mh = new MinHeapWithNodes([
-      { value: 0x1, cost: 10 },
-      { value: 0x2, cost: 1 },
-      { value: 0x3, cost: 7 },
-      { value: 0x4, cost: 3 },
-      { value: 0x5, cost: 8 },
-      { value: 0x6, cost: 5 },
-      { value: 0x7, cost: 9 },
+      { value: 0x1, fCost: 10, hCost: 0, gCost: 0 },
+      { value: 0x2, fCost: 1, hCost: 0, gCost: 0 },
+      { value: 0x3, fCost: 7, hCost: 0, gCost: 0 },
+      { value: 0x4, fCost: 3, hCost: 0, gCost: 0 },
+      { value: 0x5, fCost: 8, hCost: 0, gCost: 0 },
+      { value: 0x6, fCost: 5, hCost: 0, gCost: 0 },
+      { value: 0x7, fCost: 9, hCost: 0, gCost: 0 },
     ]);
     expect(mh.heap).toEqual([
-      { value: 0x2, cost: 1 },
-      { value: 0x4, cost: 3 },
-      { value: 0x6, cost: 5 },
-      { value: 0x1, cost: 10 },
-      { value: 0x5, cost: 8 },
-      { value: 0x3, cost: 7 },
-      { value: 0x7, cost: 9 },
+      { value: 0x2, fCost: 1, hCost: 0, gCost: 0 },
+      { value: 0x4, fCost: 3, hCost: 0, gCost: 0 },
+      { value: 0x6, fCost: 5, hCost: 0, gCost: 0 },
+      { value: 0x1, fCost: 10, hCost: 0, gCost: 0 },
+      { value: 0x5, fCost: 8, hCost: 0, gCost: 0 },
+      { value: 0x3, fCost: 7, hCost: 0, gCost: 0 },
+      { value: 0x7, fCost: 9, hCost: 0, gCost: 0 },
     ]);
   });
 
   it("constructor - arr ordered", () => {
     const mh = new MinHeapWithNodes([
-      { value: 0x1, cost: 1 },
-      { value: 0x2, cost: 2 },
-      { value: 0x3, cost: 3 },
-      { value: 0x4, cost: 4 },
-      { value: 0x5, cost: 5 },
-      { value: 0x6, cost: 6 },
-      { value: 0x7, cost: 7 },
+      { value: 0x1, fCost: 1, hCost: 0, gCost: 0 },
+      { value: 0x2, fCost: 2, hCost: 0, gCost: 0 },
+      { value: 0x3, fCost: 3, hCost: 0, gCost: 0 },
+      { value: 0x4, fCost: 4, hCost: 0, gCost: 0 },
+      { value: 0x5, fCost: 5, hCost: 0, gCost: 0 },
+      { value: 0x6, fCost: 6, hCost: 0, gCost: 0 },
+      { value: 0x7, fCost: 7, hCost: 0, gCost: 0 },
     ]);
     expect(mh.heap).toEqual([
-      { value: 0x1, cost: 1 },
-      { value: 0x2, cost: 2 },
-      { value: 0x3, cost: 3 },
-      { value: 0x4, cost: 4 },
-      { value: 0x5, cost: 5 },
-      { value: 0x6, cost: 6 },
-      { value: 0x7, cost: 7 },
+      { value: 0x1, fCost: 1, hCost: 0, gCost: 0 },
+      { value: 0x2, fCost: 2, hCost: 0, gCost: 0 },
+      { value: 0x3, fCost: 3, hCost: 0, gCost: 0 },
+      { value: 0x4, fCost: 4, hCost: 0, gCost: 0 },
+      { value: 0x5, fCost: 5, hCost: 0, gCost: 0 },
+      { value: 0x6, fCost: 6, hCost: 0, gCost: 0 },
+      { value: 0x7, fCost: 7, hCost: 0, gCost: 0 },
     ]);
   });
 
   it("insert", () => {
     const mh = new MinHeapWithNodes([]);
-    mh.insert({ value: 0x1, cost: 1 });
-    expect(mh.heap).toEqual([{ value: 0x1, cost: 1 }]);
-    mh.insert({ value: 0x2, cost: 10 });
+    mh.insert({ value: 0x1, fCost: 1, hCost: 0, gCost: 0 });
+    expect(mh.heap).toEqual([{ value: 0x1, fCost: 1, hCost: 0, gCost: 0 }]);
+    mh.insert({ value: 0x2, fCost: 10, hCost: 0, gCost: 0 });
     expect(mh.heap).toEqual([
-      { value: 0x1, cost: 1 },
-      { value: 0x2, cost: 10 },
+      { value: 0x1, fCost: 1, hCost: 0, gCost: 0 },
+      { value: 0x2, fCost: 10, hCost: 0, gCost: 0 },
     ]);
-    mh.insert({ value: 0x3, cost: 5 });
+    mh.insert({ value: 0x3, fCost: 5, hCost: 0, gCost: 0 });
     expect(mh.heap).toEqual([
-      { value: 0x1, cost: 1 },
-      { value: 0x2, cost: 10 },
-      { value: 0x3, cost: 5 },
+      { value: 0x1, fCost: 1, hCost: 0, gCost: 0 },
+      { value: 0x2, fCost: 10, hCost: 0, gCost: 0 },
+      { value: 0x3, fCost: 5, hCost: 0, gCost: 0 },
     ]);
-    mh.insert({ value: 0x4, cost: 4 });
+    mh.insert({ value: 0x4, fCost: 4, hCost: 0, gCost: 0 });
     expect(mh.heap).toEqual([
-      { value: 0x1, cost: 1 },
-      { value: 0x4, cost: 4 },
-      { value: 0x3, cost: 5 },
-      { value: 0x2, cost: 10 },
+      { value: 0x1, fCost: 1, hCost: 0, gCost: 0 },
+      { value: 0x4, fCost: 4, hCost: 0, gCost: 0 },
+      { value: 0x3, fCost: 5, hCost: 0, gCost: 0 },
+      { value: 0x2, fCost: 10, hCost: 0, gCost: 0 },
     ]);
   });
 
   it("remove", () => {
     const mh = new MinHeapWithNodes([
-      { value: 0x1, cost: 1 },
-      { value: 0x2, cost: 10 },
-      { value: 0x3, cost: 5 },
-      { value: 0x4, cost: 4 },
+      { value: 0x1, fCost: 1, hCost: 0, gCost: 0 },
+      { value: 0x2, fCost: 10, hCost: 0, gCost: 0 },
+      { value: 0x3, fCost: 5, hCost: 0, gCost: 0 },
+      { value: 0x4, fCost: 4, hCost: 0, gCost: 0 },
     ]);
     mh.remove();
     expect(mh.heap).toEqual([
-      { value: 0x4, cost: 4 },
-      { value: 0x2, cost: 10 },
-      { value: 0x3, cost: 5 },
+      { value: 0x4, fCost: 4, hCost: 0, gCost: 0 },
+      { value: 0x2, fCost: 10, hCost: 0, gCost: 0 },
+      { value: 0x3, fCost: 5, hCost: 0, gCost: 0 },
     ]);
   });
 });

--- a/src/MinHeapWithNodes.test.ts
+++ b/src/MinHeapWithNodes.test.ts
@@ -67,6 +67,26 @@ describe("MinHeapWithNodes", () => {
     ]);
   });
 
+  it("clear - clears both heap and nodeValueSet", () => {
+    const mh = new MinHeapWithNodes([
+      { value: 0x1, fCost: 1, hCost: 0, gCost: 0 },
+      { value: 0x2, fCost: 10, hCost: 0, gCost: 0 },
+      { value: 0x3, fCost: 5, hCost: 0, gCost: 0 },
+    ]);
+    expect(mh.heap.length).toBe(3);
+    expect(mh.includes(0x1)).toBe(true);
+    expect(mh.includes(0x2)).toBe(true);
+    expect(mh.includes(0x3)).toBe(true);
+
+    mh.clear();
+
+    expect(mh.heap.length).toBe(0);
+    expect(mh.size).toBe(0);
+    expect(mh.includes(0x1)).toBe(false);
+    expect(mh.includes(0x2)).toBe(false);
+    expect(mh.includes(0x3)).toBe(false);
+  });
+
   it("remove", () => {
     const mh = new MinHeapWithNodes([
       { value: 0x1, fCost: 1, hCost: 0, gCost: 0 },

--- a/src/MinHeapWithNodes.ts
+++ b/src/MinHeapWithNodes.ts
@@ -75,11 +75,19 @@ export default class MinHeapWithNodes {
 
       let smallest = nodeIndex;
 
-      if (leftChildIndex < this.heap.length && this.heap[leftChildIndex].fCost < this.heap[smallest].fCost) {
+      if (
+        leftChildIndex < this.heap.length &&
+        (this.heap[leftChildIndex].fCost < this.heap[smallest].fCost ||
+          (this.heap[leftChildIndex].fCost === this.heap[smallest].fCost && this.heap[leftChildIndex].hCost < this.heap[smallest].hCost))
+      ) {
         smallest = leftChildIndex;
       }
 
-      if (rightChildIndex < this.heap.length && this.heap[rightChildIndex].fCost < this.heap[smallest].fCost) {
+      if (
+        rightChildIndex < this.heap.length &&
+        (this.heap[rightChildIndex].fCost < this.heap[smallest].fCost ||
+          (this.heap[rightChildIndex].fCost === this.heap[smallest].fCost && this.heap[rightChildIndex].hCost < this.heap[smallest].hCost))
+      ) {
         smallest = rightChildIndex;
       }
 

--- a/src/MinHeapWithNodes.ts
+++ b/src/MinHeapWithNodes.ts
@@ -1,6 +1,11 @@
 export type MinHeapNode = {
   value: number;
-  cost: number;
+  // Heuristic cost (Manhattan/Euclidean/etc). This is the cost from this node to this goal node.
+  hCost: number;
+  // Cost from the start.
+  gCost: number;
+  // f = g + h (MinHeap should care about this)
+  fCost: number;
 };
 
 /**
@@ -70,11 +75,11 @@ export default class MinHeapWithNodes {
 
       let smallest = nodeIndex;
 
-      if (leftChildIndex < this.heap.length && this.heap[leftChildIndex].cost < this.heap[smallest].cost) {
+      if (leftChildIndex < this.heap.length && this.heap[leftChildIndex].fCost < this.heap[smallest].fCost) {
         smallest = leftChildIndex;
       }
 
-      if (rightChildIndex < this.heap.length && this.heap[rightChildIndex].cost < this.heap[smallest].cost) {
+      if (rightChildIndex < this.heap.length && this.heap[rightChildIndex].fCost < this.heap[smallest].fCost) {
         smallest = rightChildIndex;
       }
 
@@ -94,7 +99,7 @@ export default class MinHeapWithNodes {
 
     const parentNodeIndex = nodeIndex > 2 ? Math.floor((nodeIndex - 1) / 2) : 0;
 
-    if (this.heap[nodeIndex].cost >= this.heap[parentNodeIndex].cost) {
+    if (this.heap[nodeIndex].fCost >= this.heap[parentNodeIndex].fCost) {
       return;
     }
 

--- a/src/MinHeapWithNodes.ts
+++ b/src/MinHeapWithNodes.ts
@@ -77,16 +77,16 @@ export default class MinHeapWithNodes {
 
       if (
         leftChildIndex < this.heap.length &&
-        (this.heap[leftChildIndex].fCost < this.heap[smallest].fCost ||
-          (this.heap[leftChildIndex].fCost === this.heap[smallest].fCost && this.heap[leftChildIndex].hCost < this.heap[smallest].hCost))
+        this.heap[leftChildIndex].fCost < this.heap[smallest].fCost /* ||
+          (this.heap[leftChildIndex].fCost === this.heap[smallest].fCost && this.heap[leftChildIndex].hCost < this.heap[smallest].hCost)*/
       ) {
         smallest = leftChildIndex;
       }
 
       if (
         rightChildIndex < this.heap.length &&
-        (this.heap[rightChildIndex].fCost < this.heap[smallest].fCost ||
-          (this.heap[rightChildIndex].fCost === this.heap[smallest].fCost && this.heap[rightChildIndex].hCost < this.heap[smallest].hCost))
+        this.heap[rightChildIndex].fCost < this.heap[smallest].fCost /* ||
+          (this.heap[rightChildIndex].fCost === this.heap[smallest].fCost && this.heap[rightChildIndex].hCost < this.heap[smallest].hCost)*/
       ) {
         smallest = rightChildIndex;
       }

--- a/src/MinHeapWithNodes.ts
+++ b/src/MinHeapWithNodes.ts
@@ -29,6 +29,7 @@ export default class MinHeapWithNodes {
 
   public clear() {
     this.heap = [];
+    this.nodeValueSet.clear();
   }
 
   public includes(nodeValue: number): boolean {


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor the A* Pathfinding algorithm to use separate heuristic (hCost), movement (gCost), and total (fCost) costs for more accurate node evaluation and update tests accordingly.

### Why are these changes being made?

The update ensures more precise path calculations by distinguishing between the heuristic estimate to the target (hCost) and the cumulative cost from the start (gCost), with their sum (fCost) being used for node priority in the MinHeap. This approach aligns with standard A* algorithm practices to improve pathfinding efficiency and effectiveness.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->